### PR TITLE
Add documentation for installing psql client

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Check out our full documentation for [getting started](https://docs.bespokelabs.
 ```bash
 pip install bespokelabs-curator
 ```
+
+If you need PostgreSQL tooling, follow the [psql client installation notes](docs/installing_psql_client.md).
 ## 📕 Examples
 
 ### Finetuning/Distillation

--- a/docs/installing_psql_client.md
+++ b/docs/installing_psql_client.md
@@ -19,8 +19,8 @@ below to install the `psql` client on Ubuntu-based systems.
    sudo apt-get install -y postgresql-client
    ```
 
-If your network egress policy blocks access to Ubuntu or PostgreSQL mirrors you
+If your network egress policy blocks access to Ubuntu mirrors you
 will need to work with your infrastructure team to allow HTTPS traffic to those
-hosts (for example `archive.ubuntu.com`, `security.ubuntu.com`, and
-`apt.postgresql.org`). Without that access, `apt-get` will report HTTP 403
+hosts (for example `archive.ubuntu.com` and `security.ubuntu.com`).
+Without that access, `apt-get` will report HTTP 403
 errors and the installation will fail.

--- a/docs/installing_psql_client.md
+++ b/docs/installing_psql_client.md
@@ -1,0 +1,26 @@
+# Installing the `psql` Client
+
+The project occasionally relies on the PostgreSQL command line tools (e.g. when
+running integration tests or verifying external data sources). Follow the steps
+below to install the `psql` client on Ubuntu-based systems.
+
+1. Ensure that APT is allowed to talk to Ubuntu mirrors over HTTPS. On some
+   locked-down environments you may need to update `/etc/apt/sources.list.d/ubuntu.sources`
+   so that the `URIs` entries start with `https://` instead of `http://`.
+2. Refresh the package indices:
+
+   ```bash
+   sudo apt-get update
+   ```
+
+3. Install the PostgreSQL client binaries:
+
+   ```bash
+   sudo apt-get install -y postgresql-client
+   ```
+
+If your network egress policy blocks access to Ubuntu or PostgreSQL mirrors you
+will need to work with your infrastructure team to allow HTTPS traffic to those
+hosts (for example `archive.ubuntu.com`, `security.ubuntu.com`, and
+`apt.postgresql.org`). Without that access, `apt-get` will report HTTP 403
+errors and the installation will fail.


### PR DESCRIPTION
## Summary
- add a standalone guide describing how to install the PostgreSQL `psql` client with apt
- link the main README installation section to the new guide for easier discovery

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'bespokelabs.curator.code_executor')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910918c5778832d9e9369dbdd2dbb44)