### PR TITLE
Set initial code metadata last edited time

### DIFF
--- a/src/bespokelabs/curator/code_executor/db.py
+++ b/src/bespokelabs/curator/code_executor/db.py
@@ -120,7 +120,7 @@ class CodeMetadataDB:
                         metadata["code_input"],
                         metadata["code_output"],
                         metadata["timestamp"],
-                        "-",
+                        metadata["timestamp"],
                     ),
                 )
             conn.commit()

--- a/tests/code_executor/test_code_db_schema.py
+++ b/tests/code_executor/test_code_db_schema.py
@@ -99,7 +99,7 @@ def test_store_metadata_new_entry(tmp_path):
     assert row[3] == metadata["code_input"]
     assert row[4] == metadata["code_output"]
     assert row[5] == metadata["timestamp"]
-    assert row[6] == "-"  # Default last_edited_time
+    assert row[6] == metadata["timestamp"]  # Default last_edited_time
 
 
 def test_store_metadata_update_existing(tmp_path):


### PR DESCRIPTION
## Summary
- set the initial last_edited_time for code metadata entries to the run timestamp
- update the code metadata schema test to expect the stored timestamp for new entries

## Testing
- pytest tests/code_executor/test_code_db_schema.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f6145dacc832d9d251e506da9c5e5)