### PR TITLE
Add Curator Viewer dashboard starter UI

### DIFF
--- a/src/bespokelabs/curator/viewer/static/components/Dashboard.tsx
+++ b/src/bespokelabs/curator/viewer/static/components/Dashboard.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useState } from "react";
+import styles from "../styles/Dashboard.module.css";
+
+interface DashboardMetric {
+  label: string;
+  value: string;
+  trend: string;
+}
+
+interface ActivityItem {
+  title: string;
+  description: string;
+  timestamp: string;
+}
+
+interface DashboardData {
+  metrics: DashboardMetric[];
+  activities: ActivityItem[];
+}
+
+const DEFAULT_DASHBOARD_DATA: DashboardData = {
+  metrics: [
+    {
+      label: "Active Runs",
+      value: "12",
+      trend: "+3 since yesterday"
+    },
+    {
+      label: "Samples Generated",
+      value: "148k",
+      trend: "+18% week over week"
+    },
+    {
+      label: "Average Latency",
+      value: "1.4s",
+      trend: "-0.3s in the last hour"
+    },
+    {
+      label: "Quality Score",
+      value: "96%",
+      trend: "+2% in the last 24h"
+    }
+  ],
+  activities: [
+    {
+      title: "Batch export completed",
+      description: "Reasoning datasets pushed to the hosted viewer.",
+      timestamp: "2 minutes ago"
+    },
+    {
+      title: "New pipeline deployed",
+      description: "Multi-provider inference now routes through Claude 3.7.",
+      timestamp: "14 minutes ago"
+    },
+    {
+      title: "Cost alert resolved",
+      description: "Projected spend returned to target budget.",
+      timestamp: "1 hour ago"
+    }
+  ]
+};
+
+export const Dashboard = () => {
+  const [dashboardData, setDashboardData] = useState<DashboardData>(DEFAULT_DASHBOARD_DATA);
+
+  useEffect(() => {
+    const loadDashboardData = async () => {
+      try {
+        const refreshedData: DashboardData = {
+          metrics: DEFAULT_DASHBOARD_DATA.metrics,
+          activities: DEFAULT_DASHBOARD_DATA.activities
+        };
+        setDashboardData(refreshedData);
+      } catch (error) {
+        console.error("Dashboard data load failed", { error });
+      }
+    };
+
+    loadDashboardData();
+  }, []);
+
+  const metricCards = useMemo(
+    () =>
+      dashboardData.metrics.map((metric) => (
+        <div key={metric.label} className={styles.metricCard}>
+          <p className={styles.metricLabel}>{metric.label}</p>
+          <h3 className={styles.metricValue}>{metric.value}</h3>
+          <p className={styles.metricTrend}>{metric.trend}</p>
+        </div>
+      )),
+    [dashboardData.metrics]
+  );
+
+  return (
+    <main className={styles.dashboard}>
+      <header className={styles.header}>
+        <div>
+          <p className={styles.subtitle}>Curator Command Center</p>
+          <h1 className={styles.title}>Realtime Dashboard</h1>
+        </div>
+        <div className={styles.headerActions}>
+          <button className={styles.secondaryButton} type="button">
+            Export Report
+          </button>
+          <button className={styles.primaryButton} type="button">
+            Create Run
+          </button>
+        </div>
+      </header>
+
+      <section className={styles.metricsGrid}>{metricCards}</section>
+
+      <section className={styles.contentGrid}>
+        <div className={styles.panel}>
+          <h2 className={styles.panelTitle}>Operational Overview</h2>
+          <div className={styles.progressList}>
+            <div className={styles.progressItem}>
+              <div>
+                <p className={styles.progressLabel}>Pipeline Success Rate</p>
+                <p className={styles.progressValue}>98.6%</p>
+              </div>
+              <div className={styles.progressBar}>
+                <span className={styles.progressBarFill} style={{ width: "98%" }} />
+              </div>
+            </div>
+            <div className={styles.progressItem}>
+              <div>
+                <p className={styles.progressLabel}>Cache Hit Rate</p>
+                <p className={styles.progressValue}>73%</p>
+              </div>
+              <div className={styles.progressBar}>
+                <span className={styles.progressBarFill} style={{ width: "73%" }} />
+              </div>
+            </div>
+            <div className={styles.progressItem}>
+              <div>
+                <p className={styles.progressLabel}>Active Workers</p>
+                <p className={styles.progressValue}>24 / 30</p>
+              </div>
+              <div className={styles.progressBar}>
+                <span className={styles.progressBarFill} style={{ width: "80%" }} />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.panel}>
+          <h2 className={styles.panelTitle}>Recent Activity</h2>
+          <div className={styles.activityList}>
+            {dashboardData.activities.map((activity) => (
+              <div key={activity.title} className={styles.activityItem}>
+                <div className={styles.activityText}>
+                  <p className={styles.activityTitle}>{activity.title}</p>
+                  <p className={styles.activityDescription}>{activity.description}</p>
+                </div>
+                <span className={styles.activityTimestamp}>{activity.timestamp}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+};

--- a/src/bespokelabs/curator/viewer/static/components/ErrorBoundary.tsx
+++ b/src/bespokelabs/curator/viewer/static/components/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import type { ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+import styles from "../styles/ErrorBoundary.module.css";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  message?: string;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    hasError: false,
+    message: undefined
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, message: error.message };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Viewer dashboard error boundary caught", {
+      error,
+      errorInfo
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className={styles.container}>
+          <h2 className={styles.title}>Dashboard temporarily unavailable</h2>
+          <p className={styles.message}>
+            Refresh the page or check the service logs for more details.
+          </p>
+          {this.state.message ? (
+            <p className={styles.details}>Error: {this.state.message}</p>
+          ) : null}
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/bespokelabs/curator/viewer/static/next-env.d.ts
+++ b/src/bespokelabs/curator/viewer/static/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/src/bespokelabs/curator/viewer/static/next.config.js
+++ b/src/bespokelabs/curator/viewer/static/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/src/bespokelabs/curator/viewer/static/package.json
+++ b/src/bespokelabs/curator/viewer/static/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "curator-viewer",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "typescript": "5.5.4"
+  }
+}

--- a/src/bespokelabs/curator/viewer/static/pages/_app.tsx
+++ b/src/bespokelabs/curator/viewer/static/pages/_app.tsx
@@ -1,0 +1,11 @@
+import type { AppProps } from "next/app";
+import { ErrorBoundary } from "../components/ErrorBoundary";
+import "../styles/globals.css";
+
+const App = ({ Component, pageProps }: AppProps) => (
+  <ErrorBoundary>
+    <Component {...pageProps} />
+  </ErrorBoundary>
+);
+
+export default App;

--- a/src/bespokelabs/curator/viewer/static/pages/index.tsx
+++ b/src/bespokelabs/curator/viewer/static/pages/index.tsx
@@ -1,0 +1,17 @@
+import Head from "next/head";
+import { Dashboard } from "../components/Dashboard";
+
+const HomePage = () => (
+  <>
+    <Head>
+      <title>Curator Dashboard</title>
+      <meta
+        name="description"
+        content="Monitor Curator runs, cost projections, and dataset health in one view."
+      />
+    </Head>
+    <Dashboard />
+  </>
+);
+
+export default HomePage;

--- a/src/bespokelabs/curator/viewer/static/styles/Dashboard.module.css
+++ b/src/bespokelabs/curator/viewer/static/styles/Dashboard.module.css
@@ -1,0 +1,193 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 3rem 4rem 4rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.subtitle {
+  font-size: 0.9rem;
+  color: #9ea6c7;
+  text-transform: uppercase;
+  letter-spacing: 0.2rem;
+}
+
+.title {
+  font-size: 2.4rem;
+  margin-top: 0.4rem;
+}
+
+.headerActions {
+  display: flex;
+  gap: 1rem;
+}
+
+.primaryButton,
+.secondaryButton {
+  border-radius: 999px;
+  padding: 0.65rem 1.6rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryButton {
+  background: linear-gradient(120deg, #7a5cff, #3bd8ff);
+  color: #0b0d14;
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(58, 216, 255, 0.2);
+}
+
+.secondaryButton {
+  background: rgba(255, 255, 255, 0.05);
+  color: #f5f7ff;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.primaryButton:hover,
+.secondaryButton:hover {
+  transform: translateY(-1px);
+}
+
+.metricsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.metricCard {
+  background: rgba(18, 22, 34, 0.8);
+  border-radius: 1.2rem;
+  padding: 1.6rem;
+  border: 1px solid rgba(122, 92, 255, 0.2);
+  box-shadow: 0 18px 35px rgba(7, 9, 17, 0.4);
+}
+
+.metricLabel {
+  font-size: 0.95rem;
+  color: #c7cdee;
+}
+
+.metricValue {
+  font-size: 2rem;
+  margin: 0.6rem 0 0.4rem;
+}
+
+.metricTrend {
+  font-size: 0.85rem;
+  color: #7de3b8;
+}
+
+.contentGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: rgba(13, 16, 26, 0.9);
+  border-radius: 1.4rem;
+  padding: 1.8rem;
+  border: 1px solid rgba(91, 104, 158, 0.3);
+}
+
+.panelTitle {
+  font-size: 1.2rem;
+  margin-bottom: 1.4rem;
+}
+
+.progressList {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.progressItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.progressLabel {
+  color: #b4bddf;
+  font-size: 0.9rem;
+}
+
+.progressValue {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.progressBar {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.progressBarFill {
+  display: block;
+  height: 100%;
+  background: linear-gradient(120deg, #7a5cff, #3bd8ff);
+  border-radius: 999px;
+}
+
+.activityList {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.activityItem {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.activityItem:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.activityTitle {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.activityDescription {
+  font-size: 0.9rem;
+  color: #b4bddf;
+  margin-top: 0.3rem;
+}
+
+.activityTimestamp {
+  color: #9ea6c7;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .dashboard {
+    padding: 2rem;
+  }
+
+  .header {
+    align-items: flex-start;
+  }
+
+  .headerActions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}

--- a/src/bespokelabs/curator/viewer/static/styles/ErrorBoundary.module.css
+++ b/src/bespokelabs/curator/viewer/static/styles/ErrorBoundary.module.css
@@ -1,0 +1,24 @@
+.container {
+  margin: 4rem auto;
+  max-width: 520px;
+  padding: 2rem;
+  border-radius: 1.2rem;
+  background: rgba(21, 24, 38, 0.9);
+  border: 1px solid rgba(122, 92, 255, 0.3);
+  text-align: center;
+}
+
+.title {
+  font-size: 1.5rem;
+  margin-bottom: 0.8rem;
+}
+
+.message {
+  color: #c7cdee;
+  margin-bottom: 1rem;
+}
+
+.details {
+  color: #f7b2c4;
+  font-size: 0.9rem;
+}

--- a/src/bespokelabs/curator/viewer/static/styles/globals.css
+++ b/src/bespokelabs/curator/viewer/static/styles/globals.css
@@ -1,0 +1,21 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #0b0d14;
+  color: #f5f7ff;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1f2230 0%, #0b0d14 55%);
+}
+
+button {
+  font: inherit;
+}

--- a/src/bespokelabs/curator/viewer/static/tsconfig.json
+++ b/src/bespokelabs/curator/viewer/static/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, TypeScript Next.js viewer UI to monitor Curator runs, cost projections, and dataset health in a compact dashboard layout.
- Scaffold a frontend that can be extended to stream real-time run and dataset metadata from the Curator backend.

### Description
- Add a small Next.js TypeScript app under `src/bespokelabs/curator/viewer/static` including `package.json`, `tsconfig.json`, `next.config.js`, and `next-env.d.ts` to define the viewer project configuration. 
- Add page scaffolding in `pages/_app.tsx` and `pages/index.tsx` and two React components: `components/Dashboard.tsx` (metrics grid, operational overview, recent activity, and async data-load scaffold) and `components/ErrorBoundary.tsx` (React error boundary for the viewer). 
- Add dark-theme global CSS and component CSS modules in `styles/*` to style the dashboard and error UI. 
- Pin Next/React/TypeScript dev dependencies for the static viewer so it can be run locally with the provided npm scripts. 

### Testing
- Ran `npm install` in `viewer/static`, which completed but emitted warnings and reported one critical vulnerability from the pinned dependencies. 
- Started the local dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and the Next dev server compiled and served the dashboard successfully. 
- Executed a Playwright script that loaded `http://127.0.0.1:3000` and saved a screenshot to `artifacts/curator-dashboard.png` to validate the page renders. 
- No unit or automated backend tests were run for these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915fe59c7d8832d8ecf8ed3c557f4ee)